### PR TITLE
Improve `identite_salarie` for `BulletinSalaireModel`

### DIFF
--- a/document-ia-schemas/src/document_ia_schemas/bulletin_salaire.py
+++ b/document-ia-schemas/src/document_ia_schemas/bulletin_salaire.py
@@ -1,11 +1,30 @@
-from typing import Type, Optional
+import re
+from typing import Annotated, Any, Type, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, BeforeValidator
 
 from document_ia_schemas import BaseDocumentTypeSchema
 from document_ia_schemas.base_document_type_schema import FuzzyDate
 
 from document_ia_schemas.field_metrics import Metric
+
+EMPLOYEE_TITLE_PREFIX_PATTERN = re.compile(
+    r"^\s*(?:(?:m(?:onsieur)?|mme|madame|mlle|docteur|dr|prof(?:esseur)?|pr)\.?\s+)+",
+    flags=re.IGNORECASE,
+)
+
+
+def normalize_employee_identity(value: Any) -> Any:
+    if value is None or not isinstance(value, str):
+        return value
+
+    normalized_value = value.replace(",", " ").strip()
+    normalized_value = EMPLOYEE_TITLE_PREFIX_PATTERN.sub("", normalized_value)
+    normalized_value = re.sub(r"\s+", " ", normalized_value).strip()
+    return normalized_value or None
+
+
+EmployeeIdentity = Annotated[Optional[str], BeforeValidator(normalize_employee_identity)]
 
 class BulletinSalaireModel(BaseModel):
     # --- Identité Employeur ---
@@ -27,9 +46,9 @@ class BulletinSalaireModel(BaseModel):
     )
 
     # --- Identité Salarié ---
-    identite_salarie: Optional[str] = Field(
+    identite_salarie: EmployeeIdentity = Field(
         default=None,
-        description="Nom de famille et Prénoms du salarié",
+        description="Nom de famille et Prénoms du salarié. Préférer le nom du salarié tel qu'il apparaît au niveau du destinataire du bulletin de salaire (ex: \"LAFONTAINE Patrice\" plutôt que \"LAFONTAINE Patrice née DUFOUR\").",
         examples=["MARTIN Thomas"],
         json_schema_extra={
             "metrics": [

--- a/document-ia-schemas/tests/test_bulletin_salaire_postprocessing.py
+++ b/document-ia-schemas/tests/test_bulletin_salaire_postprocessing.py
@@ -1,0 +1,26 @@
+import pytest
+
+from document_ia_schemas.bulletin_salaire import BulletinSalaireModel
+
+
+@pytest.mark.parametrize(
+    ("raw_identity", "expected_identity"),
+    [
+        ("M. MARTIN Thomas", "MARTIN Thomas"),
+        ("Mme, DUPONT Jeanne", "DUPONT Jeanne"),
+        ("Docteur DURAND Alice", "DURAND Alice"),
+        ("Dr.  LAFONTAINE, Patrice", "LAFONTAINE Patrice"),
+        ("MARTIN Thomas", "MARTIN Thomas"),
+    ],
+)
+def test_identite_salarie_postprocessing_removes_titles_and_commas(
+    raw_identity: str, expected_identity: str
+):
+    # Given
+    extracted_payload = {"identite_salarie": raw_identity}
+
+    # When
+    model = BulletinSalaireModel(**extracted_payload)
+
+    # Then
+    assert model.identite_salarie == expected_identity

--- a/document-ia-worker/tests/fixtures/prompts/extraction/bulletin_salaire.txt
+++ b/document-ia-worker/tests/fixtures/prompts/extraction/bulletin_salaire.txt
@@ -2,7 +2,7 @@ Tu es un agent spécialisé dans l'extraction de données à partir de Bulletin 
 
 - **nom_employeur** : Nom ou raison sociale de l'employeur
 - **siret** : Numéro SIRET de l'employeur (14 chiffres)
-- **identite_salarie** : Nom de famille et Prénoms du salarié
+- **identite_salarie** : Nom de famille et Prénoms du salarié. Préférer le nom du salarié tel qu'il apparaît au niveau du destinataire du bulletin de salaire (ex: "LAFONTAINE Patrice" plutôt que "LAFONTAINE Patrice née DUFOUR").
 - **adresse_salarie** : Adresse postale complète du salarié
 - **periode_debut** : Date de début de la période de paie concernée (format JJ/MM/AAAA)
 - **periode_fin** : Date de fin de la période de paie concernée (format JJ/MM/AAAA)
@@ -40,7 +40,7 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 ## Informations à extraire
 - **nom_employeur**: Nom ou raison sociale de l'employeur
 - **siret**: Numéro SIRET de l'employeur (14 chiffres)
-- **identite_salarie**: Nom de famille et Prénoms du salarié
+- **identite_salarie**: Nom de famille et Prénoms du salarié. Préférer le nom du salarié tel qu'il apparaît au niveau du destinataire du bulletin de salaire (ex: "LAFONTAINE Patrice" plutôt que "LAFONTAINE Patrice née DUFOUR").
 - **adresse_salarie**: Adresse postale complète du salarié
 - **periode_debut**: Date de début de la période de paie concernée (format JJ/MM/AAAA)
 - **periode_fin**: Date de fin de la période de paie concernée (format JJ/MM/AAAA)


### PR DESCRIPTION
- New instruction for `identite_salarie`
- Add postprocessing to remove titles


Note: the JSON Schema is correctly set, even with this `BeforeValidation` annotation:
```
'identite_salarie': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'default': None, 'description': 'Nom de famille et Prénoms du salarié. Préférer le nom du salarié tel qu\'il apparaît au niveau du destinataire du bulletin de salaire (ex: "LAFONTAINE Patrice" plutôt que "LAFONTAINE Patrice née DUFOUR").', 'examples': ['MARTIN Thomas'], 'metrics': ['token_set_equality', 'levenshtein_distance'], 'title': 'Identite Salarie'}
```