### PR TITLE
Cleaning prompts

### DIFF
--- a/document-ia-worker/src/document_ia_worker/core/prompt/prompt_service.py
+++ b/document-ia-worker/src/document_ia_worker/core/prompt/prompt_service.py
@@ -115,14 +115,9 @@ class PromptService:
                 for example in schema_instance.examples
             ]
 
-            document_json_properties_with_description: Dict[str, str] = {
-                key: value.get("description") for key, value in properties.items()
-            }
-
             prompt_text = prompt_template.render(
                 document_name=schema_instance.name,
                 document_description=schema_instance.description,
-                document_json_properties_with_description=document_json_properties_with_description,
                 extraction_response_format=extraction_response_format,
                 extraction_examples=extraction_examples,
                 nested_fields_info=nested_fields_info,

--- a/document-ia-worker/src/document_ia_worker/core/prompt/prompts/extraction_agent_system_prompt.md.j2
+++ b/document-ia-worker/src/document_ia_worker/core/prompt/prompts/extraction_agent_system_prompt.md.j2
@@ -47,7 +47,9 @@ Voici des exemples de réponses attendues :
 
 {% for example in extraction_examples -%}
 Exemple {{ loop.index }} :
+```
 {{ example | tojson(indent=2) }}
+```
 {% endfor %}
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/src/document_ia_worker/core/prompt/prompts/extraction_agent_system_prompt.md.j2
+++ b/document-ia-worker/src/document_ia_worker/core/prompt/prompts/extraction_agent_system_prompt.md.j2
@@ -26,9 +26,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-{{ document_json_properties_with_description | dict_to_bullets }}
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/fixtures/regenerate_extraction_prompt_fixtures.py
+++ b/document-ia-worker/tests/fixtures/regenerate_extraction_prompt_fixtures.py
@@ -8,7 +8,7 @@ from document_ia_worker.exception.unsupported_document_type import (
 
 
 def main() -> None:
-    output_dir = Path(__file__).resolve().parent / "prompts" / "extraction"
+    output_dir = Path(__file__).resolve().parent.parent / "snapshots" / "prompts" / "extraction"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     prompt_service = PromptService()

--- a/document-ia-worker/tests/snapshots/prompts/extraction/attestation_contrat_energie.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/attestation_contrat_energie.txt
@@ -38,15 +38,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **date_emission**: Date d'émission de l'attestation.
-- **nom_fournisseur**: Nom ou raison sociale du fournisseur de service
-- **siret_fournisseur**: Numéro SIRET du fournisseur de service (14 chiffres)
-- **beneficiaires**: Liste des bénéficiaires du contrat
-- **adresse_beneficiaire**: Adresse postale complète du bénéficiaire (adresse de livraison du service)
-- **numero_contrat**: Numéro de contrat ou d'abonnement avec le fournisseur
-- **date_debut_contrat**: Date de début du contrat. Si absente, renseigner `null`.
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/attestation_contrat_energie.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/attestation_contrat_energie.txt
@@ -76,6 +76,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "date_emission": "2024-01-15",
   "nom_fournisseur": "EDF",
@@ -89,7 +90,9 @@ Exemple 1 :
   "numero_contrat": "ELEC-458796214",
   "date_debut_contrat": "2024-01-01"
 }
+```
 Exemple 2 :
+```
 {
   "date_emission": "2024-02-28",
   "nom_fournisseur": "ENGIE",
@@ -106,6 +109,7 @@ Exemple 2 :
   "numero_contrat": "GAZ-998745120",
   "date_debut_contrat": "2024-01-10"
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/attestation_hebergement.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/attestation_hebergement.txt
@@ -65,6 +65,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "hebergeur": {
     "identite": "DUPONT Marie",
@@ -81,7 +82,9 @@ Exemple 1 :
   "lieu_redaction": "Paris",
   "presence_signature_hebergeur": true
 }
+```
 Exemple 2 :
+```
 {
   "hebergeur": {
     "identite": "BERNARD Chloe",
@@ -98,6 +101,7 @@ Exemple 2 :
   "lieu_redaction": "Lyon",
   "presence_signature_hebergeur": true
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/attestation_hebergement.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/attestation_hebergement.txt
@@ -33,14 +33,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **hebergeur**: Identite complete de l'hebergeur.
-- **heberge**: Identite complete de la personne hebergee.
-- **adresse_complete_hebergement**: Adresse complete du lieu de residence.
-- **date_redaction**: Date de redaction de l'attestation.
-- **lieu_redaction**: Lieu de redaction de l'attestation.
-- **presence_signature_hebergeur**: Indique si la signature de l'hebergeur est detectee.
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/avis_imposition.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/avis_imposition.txt
@@ -96,6 +96,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "annee_revenus": "2023",
   "date_mise_en_recouvrement": "2024-07-31",
@@ -113,7 +114,9 @@ Exemple 1 :
   "impot_revenu_net_avant_corrections": 5500.0,
   "montant_impot": 5000.0
 }
+```
 Exemple 2 :
+```
 {
   "annee_revenus": "2023",
   "date_mise_en_recouvrement": "2024-07-31",
@@ -131,6 +134,7 @@ Exemple 2 :
   "impot_revenu_net_avant_corrections": 5500.0,
   "montant_impot": 5000.0
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/avis_imposition.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/avis_imposition.txt
@@ -46,23 +46,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **annee_revenus**: Année fiscale concernée par la déclaration de revenus (format AAAA)
-- **date_mise_en_recouvrement**: Date de mise en recouvrement de l'impôt (format JJ/MM/AAAA). Si absente, renseigner `null`.
-- **declarant_1_identite**: Nom et prénom du premier déclarant tel qu'il apparait au niveau du destinataire
-- **declarant_1_nom_naissance**: Nom de naissance du premier déclarant, il peut être différent du nom et prénom du déclarant 1
-- **declarant_1_numero_fiscal**: Numéro fiscal personnel du premier déclarant (13 chiffres)
-- **declarant_2_identite**: Nom et prénom du deuxième déclarant tel qu'il apparait au niveau du destinataire
-- **declarant_2_nom_naissance**: Nom de naissance du deuxième déclarant, il peut être différent du nom et prénom du déclarant 2
-- **declarant_2_numero_fiscal**: Numéro fiscal personnel du deuxième déclarant (13 chiffres)
-- **reference_avis**: Référence unique de l'avis d'imposition (format numérique, généralement 13 ou 14 chiffres). Information présente juste après la mention "référence de l'avis".
-- **nombre_parts**: Nombre de parts fiscales du foyer (peut être décimal)
-- **revenu_fiscal_reference**: Revenu fiscal de référence (RFR) du foyer en euros
-- **revenu_brut_global**: Revenu brut global du foyer en euros.
-- **revenu_imposable**: Revenu net imposable du foyer en euros.
-- **impot_revenu_net_avant_corrections**: Montant de l'impôt sur le revenu net avant corrections en euros.
-- **montant_impot**: Montant total de l'impôt à payer ou remboursement en euros (peut être négatif).
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/bulletin_salaire.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/bulletin_salaire.txt
@@ -77,6 +77,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "nom_employeur": "ACME CORPORATION",
   "siret": "12345678900012",
@@ -89,7 +90,9 @@ Exemple 1 :
   "net_imposable": 2800.0,
   "cumul_net_imposable": 32500.0
 }
+```
 Exemple 2 :
+```
 {
   "nom_employeur": "BOULANGERIE DUPONT",
   "siret": "12345678900012",
@@ -102,7 +105,9 @@ Exemple 2 :
   "net_imposable": 2800.0,
   "cumul_net_imposable": 32500.0
 }
+```
 Exemple 3 :
+```
 {
   "nom_employeur": "Madame DURAND Valérie",
   "siret": "40536786300099",
@@ -115,6 +120,7 @@ Exemple 3 :
   "net_imposable": 1850.5,
   "cumul_net_imposable": 3701.0
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/bulletin_salaire.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/bulletin_salaire.txt
@@ -37,18 +37,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **nom_employeur**: Nom ou raison sociale de l'employeur. Dans le texte, c'est généralement la **TOUTE PREMIÈRE personne ou entité** mentionnée au début du document. Si l'employeur est un particulier, son nom apparaîtra avant celui du salarié. Les informations de l'employeur sont souvent situées juste à côté du numéro SIRET ou du code NAF/APE.
-- **siret**: Numéro SIRET de l'employeur (14 chiffres)
-- **identite_salarie**: Nom de famille et Prénoms du salarié. Dans la lecture du texte, il apparaît **APRÈS** l'employeur. Pour confirmer qu'il s'agit du salarié, cherche les éléments qui l'entourent souvent : son adresse personnelle, son numéro de Sécurité Sociale, son matricule, ou l'intitulé de son poste. Préférer le nom du salarié tel qu'il apparaît au niveau du destinataire du bulletin de salaire (ex: "LAFONTAINE Patrice" plutôt que "LAFONTAINE Patrice née DUFOUR").
-- **adresse_salarie**: Adresse postale complète du salarié
-- **periode_debut**: Date de début de la période de paie concernée (format JJ/MM/AAAA)
-- **periode_fin**: Date de fin de la période de paie concernée (format JJ/MM/AAAA)
-- **date_paiement**: Date de mise en paiement du salaire (format JJ/MM/AAAA)
-- **date_debut_contrat**: Date d'ancienneté ou d'entrée dans l'entreprise (format JJ/MM/AAAA), si absente, renseigner `null`.
-- **net_imposable**: Montant du Net Imposable (base pour les impôts)
-- **cumul_net_imposable**: Cumul annuel du Net Imposable (souvent en bas de page), si absente, renseigner `null`.
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/cni.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/cni.txt
@@ -38,17 +38,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **numero_document**: Identifiant unique de la carte d'identité (format alphanumérique)
-- **date_delivrance**: Date d'émission du document (format JJ MM AAAA). Si absente, renseigner `null`.
-- **date_expiration**: Date limite de validité du document (format JJ MM AAAA). Une carte d'identité est valide 10 ans. Si absente renseigner `null`.
-- **nom**: Nom de famille du titulaire (en majuscules sur le document)
-- **prenom**: Prénom du titulaire, uniquement le premier s'il y en a plusieurs
-- **date_naissance**: Date de naissance du titulaire (format JJ MM AAAA). Si absente renseigner `null`.
-- **lieu_naissance**: Lieu de naissance du titulaire
-- **nationalite**: Nationalité du titulaire (en majuscules sur le document)
-- **bande_mrz**: Bande Mrz de la carte d'identité (Machine Readable Zone). Si absent, renseigné `null`.
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/cni.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/cni.txt
@@ -76,6 +76,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "numero_document": "123456789012",
   "date_delivrance": "2010-01-01",
@@ -87,6 +88,7 @@ Exemple 1 :
   "nationalite": "FRANÇAISE",
   "bande_mrz": "IDFRADUPONT\u003c\u003cJEAN\u003cROBIN\u003cADRIEN\u003c\u003c\u003c\u003e\u003c\u003e\u003c\u003c\u003c\u003c\u003c\u003e\u003e\u003e123456789012FRA0002152F2809160\u003c\u003c\u003c\u003c\u003c\u003c\u003c\u003c\u003c\u003c\u003c\u003c\u003c\u003c00"
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/facture_energie.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/facture_energie.txt
@@ -40,16 +40,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **date_emission**: Date d'émission de la facture
-- **nom_fournisseur**: Nom ou raison sociale du fournisseur de service
-- **siret_fournisseur**: Numéro SIRET du fournisseur de service (14 chiffres)
-- **beneficiaires**: Liste des bénéficiaires du service
-- **adresse_beneficiaire**: Adresse postale complète du bénéficiaire (adresse de livraison du service)
-- **numero_contrat**: Numéro de contrat ou d'abonnement avec le fournisseur
-- **numero_facture**: Numéro unique de la facture
-- **montant_ttc**: Montant total toutes taxes comprises (TTC) en euros
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/facture_energie.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/facture_energie.txt
@@ -80,6 +80,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "date_emission": "2024-01-15",
   "nom_fournisseur": "EDF",
@@ -94,7 +95,9 @@ Exemple 1 :
   "numero_facture": "FAC-2024-001234",
   "montant_ttc": 125.5
 }
+```
 Exemple 2 :
+```
 {
   "date_emission": "2024-02-28",
   "nom_fournisseur": "ENGIE",
@@ -112,6 +115,7 @@ Exemple 2 :
   "numero_facture": "FAC-2024-004892",
   "montant_ttc": 214.9
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/passeport.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/passeport.txt
@@ -37,17 +37,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **numero_document**: Identifiant unique / Numéro du passeport (format alphanumérique)
-- **nom**: Nom de famille du titulaire (en majuscules sur le document)
-- **prenom**: Prénom du titulaire (premier prénom)
-- **lieu_naissance**: Lieu de naissance du titulaire (ville)
-- **nationalite**: Nationalité du titulaire
-- **bande_mrz**: Bande MRZ du passeport
-- **date_delivrance**: Date d'émission du passeport (format JJ/MM/AAAA). Si absente, renseigner `null`.
-- **date_expiration**: Date limite de validité du passeport (format JJ/MM/AAAA). Si absente, renseigner `null`.
-- **date_naissance**: Date de naissance du titulaire (format JJ/MM/AAAA). Si absente, renseigner `null`.
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/passeport.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/passeport.txt
@@ -75,6 +75,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "numero_document": "123456789012",
   "nom": "DUPONT",
@@ -86,6 +87,7 @@ Exemple 1 :
   "date_expiration": "2020-01-01",
   "date_naissance": "1990-01-01"
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/permis_conduire.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/permis_conduire.txt
@@ -38,16 +38,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **numero_document**: Identifiant unique du permis de conduire (format alphanumérique).
-- **date_delivrance**: Date de délivrance du permis de conduire (format JJ/MM/AAAA). Si absente, renseigner `null`.
-- **date_expiration**: Date limite de validité du permis de conduire (format JJ/MM/AAAA). Si absente, renseigner `null`.
-- **nom**: Nom de famille du titulaire (en majuscules sur le document).
-- **prenom**: Prénom du titulaire (premier prénom).
-- **date_naissance**: Date de naissance du titulaire (format JJ/MM/AAAA). Si absente, renseigner `null`.
-- **lieu_naissance**: Lieu de naissance du titulaire (ville). Si absente, renseigner `null`.
-- **adresse**: Adresse de résidence du titulaire. Si absente, renseigner `null`.
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/permis_conduire.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/permis_conduire.txt
@@ -74,6 +74,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "numero_document": "1234567890123456789",
   "date_delivrance": "2010-06-15",
@@ -84,6 +85,7 @@ Exemple 1 :
   "lieu_naissance": "PARIS",
   "adresse": "123 Rue de la Paix, 75008 Paris"
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/quittance_loyer.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/quittance_loyer.txt
@@ -40,20 +40,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **nature_document**: Nature du document immobilier (quittance, recu partiel, avis d'echeance).
-- **type_parc**: Type de parc locatif (prive ou social/HLM).
-- **bailleur**: Informations d'identification du bailleur ou mandataire.
-- **locataires**: Liste des locataires mentionnes sur la quittance.
-- **adresse_bien_loue**: Adresse du logement loue.
-- **periode_debut**: Date de debut de la periode couverte.
-- **periode_fin**: Date de fin de la periode couverte.
-- **date_paiement**: Date de reception effective du paiement.
-- **date_emission**: Date d'emission de la quittance.
-- **loyer_de_base**: Montant du loyer hors charges.
-- **provisions_charges**: Montant des provisions sur charges.
-- **presence_signature**: Indique si une signature/cachet de validation est detectee.
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/quittance_loyer.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/quittance_loyer.txt
@@ -88,6 +88,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "nature_document": "quittance",
   "type_parc": "prive",
@@ -111,7 +112,9 @@ Exemple 1 :
   "provisions_charges": 70.0,
   "presence_signature": true
 }
+```
 Exemple 2 :
+```
 {
   "nature_document": "quittance",
   "type_parc": "social",
@@ -135,6 +138,7 @@ Exemple 2 :
   "provisions_charges": 90.0,
   "presence_signature": null
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/taxe_fonciere.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/taxe_fonciere.txt
@@ -35,16 +35,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **annee_imposition**: Annee d'imposition de la taxe fonciere (format AAAA).
-- **date_mise_en_recouvrement**: Date de mise en recouvrement de la taxe fonciere.
-- **proprietaire_identite**: Identite du proprietaire impose.
-- **adresse_bien_impose**: Adresse du bien immobilier concerne par la taxe fonciere.
-- **reference_avis**: Reference unique de l'avis de taxe fonciere.
-- **base_nette_imposition**: Base nette d'imposition en euros.
-- **montant_taxe_fonciere**: Montant de la taxe fonciere hors frais annexes en euros.
-- **montant_total_a_payer**: Montant total a payer de la taxe fonciere en euros.
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/taxe_fonciere.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/taxe_fonciere.txt
@@ -71,6 +71,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "annee_imposition": "2025",
   "date_mise_en_recouvrement": "2025-08-31",
@@ -81,7 +82,9 @@ Exemple 1 :
   "montant_taxe_fonciere": 1185.0,
   "montant_total_a_payer": 1240.0
 }
+```
 Exemple 2 :
+```
 {
   "annee_imposition": "2025",
   "date_mise_en_recouvrement": "2025-09-15",
@@ -92,6 +95,7 @@ Exemple 2 :
   "montant_taxe_fonciere": 930.0,
   "montant_total_a_payer": 972.5
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/visale_certificate.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/visale_certificate.txt
@@ -33,12 +33,6 @@ Les textes OCR peuvent contenir des erreurs, des imprécisions ou des zones illi
 5. Distingue clairement les informations relatives au document (numéro, dates) de celles relatives à la personne
 6. Renvoie UNIQUEMENT un objet JSON conforme au schéma spécifié, sans texte explicatif ni commentaire
 
-## Informations à extraire
-- **numero_visa**: Numéro unique du visa Visale (commence généralement par la lettre V suivie de chiffres)
-- **date_delivrance**: Date d'attribution ou de délivrance du visa (format JJ/MM/AAAA). Si absente, renseigner `null`.
-- **date_fin_validite**: Date limite jusqu'à laquelle le visa est valable pour la signature du bail (format JJ/MM/AAAA).
-- **beneficiaires**: Liste des candidats locataires (bénéficiaires) mentionnés sur le certificat. Lorsque plusieurs locataires sont couverts par la même garantie VISALE, leurs différentes identités sont déclinées (Prénom 1, Nom 1)
-
 ## Vérification finale avant réponse
 - Vérifie une dernière fois que tu n'as PAS INVENTÉ de données manquantes.
 - Confirme que les champs pour lesquels aucune information n'est disponible sont bien définis comme `null`.

--- a/document-ia-worker/tests/snapshots/prompts/extraction/visale_certificate.txt
+++ b/document-ia-worker/tests/snapshots/prompts/extraction/visale_certificate.txt
@@ -66,6 +66,7 @@ Réponds UNIQUEMENT avec un objet JSON au format suivant :
 Voici des exemples de réponses attendues :
 
 Exemple 1 :
+```
 {
   "numero_visa": "V11706816406",
   "date_delivrance": "2026-03-02",
@@ -77,7 +78,9 @@ Exemple 1 :
     }
   ]
 }
+```
 Exemple 2 :
+```
 {
   "numero_visa": "V11706816406",
   "date_delivrance": "2026-03-02",
@@ -89,7 +92,9 @@ Exemple 2 :
     }
   ]
 }
+```
 Exemple 3 :
+```
 {
   "numero_visa": "V11706816406",
   "date_delivrance": "2026-03-02",
@@ -101,6 +106,7 @@ Exemple 3 :
     }
   ]
 }
+```
 
 
 N'ajoute pas de texte avant ou après le JSON final.


### PR DESCRIPTION
- Add missing backticks around examples
- Remove "Informations à extraire" section