### PR TITLE
Add classification prompt snapshot test

### DIFF
--- a/document-ia-worker/tests/fixtures/regenerate_extraction_prompt_fixtures.py
+++ b/document-ia-worker/tests/fixtures/regenerate_extraction_prompt_fixtures.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
-from document_ia_worker.core.prompt.prompt_configuration import SupportedDocumentType
+from document_ia_worker.core.prompt.prompt_configuration import (
+    GENERIC_CLASSIFICATION_MODEL,
+    SupportedDocumentType,
+)
 from document_ia_worker.core.prompt.prompt_service import PromptService
 from document_ia_worker.exception.unsupported_document_type import (
     UnsupportedDocumentType,
@@ -8,10 +11,20 @@ from document_ia_worker.exception.unsupported_document_type import (
 
 
 def main() -> None:
-    output_dir = Path(__file__).resolve().parent.parent / "snapshots" / "prompts" / "extraction"
-    output_dir.mkdir(parents=True, exist_ok=True)
+    snapshots_dir = Path(__file__).resolve().parent.parent / "snapshots" / "prompts"
+    extraction_output_dir = snapshots_dir / "extraction"
+    classification_output_dir = snapshots_dir / "classification"
+    extraction_output_dir.mkdir(parents=True, exist_ok=True)
+    classification_output_dir.mkdir(parents=True, exist_ok=True)
 
     prompt_service = PromptService()
+
+    classification_prompt = prompt_service.get_classification_prompt(
+        GENERIC_CLASSIFICATION_MODEL
+    )
+    classification_output_path = classification_output_dir / "generic.txt"
+    classification_output_path.write_text(classification_prompt, encoding="utf-8")
+    print(f"Updated: {classification_output_path}")
 
     for document_type in SupportedDocumentType:
         try:
@@ -19,7 +32,7 @@ def main() -> None:
         except UnsupportedDocumentType:
             continue
 
-        output_path = output_dir / f"{document_type.value}.txt"
+        output_path = extraction_output_dir / f"{document_type.value}.txt"
         output_path.write_text(prompt_text, encoding="utf-8")
         print(f"Updated: {output_path}")
 

--- a/document-ia-worker/tests/snapshots/prompts/classification/generic.txt
+++ b/document-ia-worker/tests/snapshots/prompts/classification/generic.txt
@@ -1,0 +1,140 @@
+Tu es un agent spécialisé dans la classification de documents. Ta mission est d'analyser le contenu d'un document issu d'un OCR et de déterminer avec précision sa nature parmi les catégories suivantes :
+
+- cni
+- passeport
+- permis_conduire
+- avis_imposition
+- bulletin_salaire
+- visale_certificate
+- quittance_loyer
+- facture_energie
+- attestation_contrat_energie
+- attestation_hebergement
+- taxe_fonciere
+- autre
+
+## Instructions
+
+1. Analyse minutieusement le texte fourni en entrée, qui est issu d'un OCR de document
+2. Identifie les caractéristiques DISTINCTIVES et CLÉS (titre, structure, mentions officielles) permettant de classifier le document.
+3. Sélectionne une UNE SEULE catégorie parmi la liste des types de documents autorisés
+4. Si une seule des caractéristiques essentielles manque ou est ambiguë, classe le document comme `autre`.
+5. Renvoie ta classification sous format JSON uniquement, sans aucun texte additionnel.
+
+## Caractéristiques distinctives par type de document
+
+
+**Carte nationale d'identité** (cni)
+- Document officiel français (carte nationale d'identité ou CNI)
+- Contient des mentions comme "République Française"
+- Présence d'informations : nom, prénom, date et lieu de naissance
+- Numéro de carte à 12 chiffres
+- Date de délivrance et date d'expiration
+- Mention de l'autorité de délivrance (préfécture ou sous-préfécture)
+- Peut contenir des codes MRZ (Machine Readable Zone) sous forme de lignes de caractères avec symboles <
+
+**Passeport** (passeport)
+- Document de voyage international
+- Mentions "Passeport", "Passport" ou "Union Européenne"
+- Numéro de passeport (généralement alphanumériques)
+- Présence d'informations : nom, prénom, date et lieu de naissance, nationalité
+- Dates de délivrance et d'expiration
+- Peut contenir des codes MRZ (Machine Readable Zone) sous forme de lignes de caractères avec symboles <
+
+**Permis de conduire** (permis_conduire)
+- Document officiel permettant de conduire un véhicule sur la voie publique
+- Format carte avec mentions "Permis de conduire" ou "Driving licence"
+- Contient des mentions comme "République Française" ou "Union Européenne"
+- Catégories de permis (A, B, etc.)
+- Numéro de permis à 12 chiffres
+- Présence d'informations : nom, prénom, date et lieu de naissance, adresse, numéro de permis
+- Dates de délivrance et d'expiration pour chaque catégorie
+- Photo d'identité du titulaire, signature et éventuellement une puce électronique
+
+**Avis d'imposition** (avis_imposition)
+- Document officiel français émis par la Direction Générale des Finances Publiques (DGFiP)
+- Contient des mentions comme "Impôts.gouv.fr" ou "Direction Générale des Finances Publiques"
+- Présence d'informations fiscales : revenus, impôts, nombre de parts
+- Référence d'avis unique (numéro à 13 ou 14 chiffres)
+- Identifie le ou les déclarants (nom, prénom, numéro fiscal)
+- Indique l'année des revenus déclarés
+- Mentionne le revenu fiscal de référence (RFR)
+- Date de mise en recouvrement de l'impôt
+- Peut contenir un QR code pour vérification en ligne
+
+**Bulletin de salaire** (bulletin_salaire)
+- Document officiel de paie (Fiche de paie / Bulletin de salaire)
+- Contient des mentions comme 'Bulletin de paie', 'Salaire', 'Employeur', 'Salarié'
+- Présence d'un tableau avec des colonnes (libellé, base, taux, montant)
+- Contient des montants Brut, Net Imposable et Net à Payer
+- Mentionne souvent l'URSSAF, la CSG, la CRDS
+
+**Certificat de garantie Visale** (visale_certificate)
+- Doit obligatoirement contenir l'intégralité du certificat officiel Action Logement, même si le document comporte également des captures d'écran web/mobile ou des e-mails parasites en première page ou en pièce jointe.
+- Présence du titre officiel ou équivalent : "Certificat à remettre au bailleur pour la souscription d'un contrat Visale" (ou "Remettez ce certificat à votre bailleur...").
+- Contient impérativement la formule d'engagement : "Action Logement certifie que le(s) candidat(s) mentionné(s) ci-dessous bénéficie (nt) de la garantie Visale" ou "ACTION LOGEMENT SE PORTE CAUTION".
+- Présence d'un numéro de visa unique (ex: Visa n°V123456789) accompagné des mentions "attribué le" et "ce visa est valable jusqu'au".
+- Indique les plafonds de loyer mensuel charges comprises (ex: montant maximum en Île-de-France, etc.).
+- Présence de la section d'instructions au bailleur ("Bailleur, comment activer votre garantie").
+- EXCLUSION : Si le document contient UNIQUEMENT une capture d'écran de l'espace client (dashboard, statut "en attente d'acceptation", bouton "ANNULER MON VISA", etc.) ou un e-mail SANS que le texte du certificat officiel ne soit présent plus bas dans le texte de l'OCR, le classer en `autre`.
+
+**Quittance de loyer** (quittance_loyer)
+- Document attestant le paiement du loyer et des charges pour une periode donnee
+- Peut etre emis par un bailleur particulier, une personne morale ou une agence immobiliere
+- Distingue le loyer hors charges, les provisions et le total acquitte
+- Peut inclure des lignes specifiques: CAF/APL, regularisation, TEOM, SLS, indexation IRL
+- La quittance est differente d'un recu partiel et d'un avis d'echeance
+
+**Facture d'énergie** (facture_energie)
+- Document émis par un fournisseur de service facturant un service d'énergie.
+- Mentions "Facture", "Facture d'énergie", ou "Facture d'électricité"
+- Nom et coordonnées du bénéficiaire
+- Nom et coordonnées du fournisseur de service
+- Date de la facture
+- Détails du service (électricité, énergie, télécom, etc.)
+- Numéro de facture
+- Montant TTC
+- Signature et cachet du fournisseur
+
+**Attestation de contrat d'énergie** (attestation_contrat_energie)
+- Document émis par un fournisseur de service certifiant qu'un bénéficiaire a bien contracté avec le fournisseur.
+- Mentions "Attestation de contrat", "Certificat de contrat", ou "Contrat"
+- Nom et coordonnées du bénéficiaire
+- Nom et coordonnées du fournisseur de service
+- Date de début du contrat
+- Détails du service (électricité, énergie, télécom, etc.)
+- Numéro de contrat/abonnement
+- Signature et cachet du fournisseur
+
+**Attestation d'hebergement** (attestation_hebergement)
+- Lettre signee par l'hebergeur certifiant sur l'honneur l'hebergement a titre gratuit
+- Contient l'identite de l'hebergeur et de la personne hebergee
+- Contient l'adresse complete d'hebergement
+- Mentionne en general un hebergement depuis plus de 3 mois
+- Indique la date et le lieu de redaction ainsi que la signature de l'hebergeur
+
+**Taxe fonciere** (taxe_fonciere)
+- Document fiscal local relatif a la taxe fonciere sur les proprietes
+- Contient une reference d'avis et une annee d'imposition
+- Identifie les propriétaires imposés et le bien immobilier concerne
+- Mentionne la base d'imposition et les montants a payer
+- Peut contenir la date de mise en recouvrement
+
+
+## Format de réponse
+Réponds UNIQUEMENT avec un objet JSON au format suivant :
+
+```json
+{
+  "document_type": "type_du_document",
+  "confidence": 0.XX,
+  "explanation": "Explication concise de ta classification"
+}
+```
+
+Où :
+- `document_type` est l'une des catégories autorisées
+- `confidence` est un score entre 0 et 1 indiquant ton niveau de certitude
+- `explanation` est une brève justification de ton choix (maximum 200 caractères)
+
+N'ajoute pas de texte avant ou après ce JSON.

--- a/document-ia-worker/tests/unit/test_prompt_service.py
+++ b/document-ia-worker/tests/unit/test_prompt_service.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 import pytest
 
-from document_ia_worker.core.prompt.prompt_configuration import SupportedDocumentType
+from document_ia_worker.core.prompt.prompt_configuration import (
+    GENERIC_CLASSIFICATION_MODEL,
+    SupportedDocumentType,
+)
 from document_ia_worker.core.prompt.prompt_service import PromptService
 from document_ia_worker.exception.unsupported_document_type import (
     UnsupportedDocumentType,
@@ -11,6 +14,9 @@ from document_ia_worker.exception.unsupported_document_type import (
 
 EXPECTED_EXTRACTION_PROMPTS_DIR = (
     Path(__file__).resolve().parents[1] / "snapshots" / "prompts" / "extraction"
+)
+EXPECTED_CLASSIFICATION_PROMPTS_DIR = (
+    Path(__file__).resolve().parents[1] / "snapshots" / "prompts" / "classification"
 )
 
 
@@ -61,6 +67,24 @@ class TestPromptService:
         assert '"document_type"' in rendered
         assert '"confidence"' in rendered
         assert '"explanation"' in rendered
+
+    def test_classification_prompt_matches_generic_snapshot(self):
+        service = PromptService()
+
+        rendered = service.get_classification_prompt(GENERIC_CLASSIFICATION_MODEL)
+
+        expected_prompt_path = EXPECTED_CLASSIFICATION_PROMPTS_DIR / "generic.txt"
+        assert (
+            expected_prompt_path.exists()
+        ), "Missing expected classification prompt fixture"
+        expected_prompt_text = expected_prompt_path.read_text(
+            encoding="utf-8"
+        ).rstrip("\n")
+        assert rendered == expected_prompt_text, (
+            "Rendered classification prompt does not match expected fixture. "
+            "Use the script `regenerate_extraction_prompt_fixtures.py` to update "
+            "the expected prompt fixture if intentional changes were made"
+        )
 
     def test_classification_prompt_is_cwd_independent(self, tmp_path, monkeypatch):
         # Change CWD to a temporary directory to ensure PromptService resolves paths relative to its file


### PR DESCRIPTION
# Description

Ensure the rendered generic classification prompt is covered by a full snapshot, matching the existing extraction prompt snapshot tests and making prompt changes explicit in test diffs.

## Type of change

Add a new test.

## Context

Tests exist for prompt extraction but not for classification.
